### PR TITLE
remove error-causing <?>

### DIFF
--- a/Tutorial_02/README.md
+++ b/Tutorial_02/README.md
@@ -143,7 +143,7 @@ Declare a method header for generic method, `allTransportation` that returns not
 ## Solution (Q7)
 
 ```java
-public <?> void allTransportation(ArrayList<?> arr1, ArrayList<?> arr2)
+public void allTransportation(ArrayList<?> arr1, ArrayList<?> arr2)
 ```
 
 # Question 08
@@ -160,7 +160,7 @@ Using the `<?>` wildcard, implement a generic method that displays the list.
 ## Solution (Q8)
 
 ```java
-public <?> void display(ArrayList<?> arr) {
+public void display(ArrayList<?> arr) {
     for (int i = 0; i < arr.size(); i++) { System.out.printf("%s ", arr.get(i)); }
     System.out.println();
 }


### PR DESCRIPTION
putting `public <?> void methodName` actually causes an `unexpected wildcard` error. after some research, if wildcards are used in method parameters the `<?>` is not needed in `public void` unlike `<T>` or <E>` etc.

src: https://stackoverflow.com/questions/18176594/when-to-use-generic-methods-and-when-to-use-wild-card